### PR TITLE
Added Squadcast to services

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Awesome list of status pages open source software, online services and public st
 * [Statuspal.io](https://statuspal.io)
 * [Sorry™](https://www.sorryapp.com)
 * [Statusy](https://statusy.co)
+* [Squadcast](https://www.squadcast.com) - On-Call & SRE platform with StatusPages built-in
 
 ## Public status pages
 * [Amazon AWS Service health dashboard](https://status.aws.amazon.com/)


### PR DESCRIPTION
Squadcast is an on-call Incident management and SRE platform. They just launched public and private statuspages as one of the feature within their product.

Squadcast support page for StatusPage - https://support.squadcast.com/docs/statuspage
