### PR TITLE
Add deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Awesome list of status pages open source software, online services and public st
 ## Opensource
 * [Cachet](https://cachethq.io/) - Laravel based status page system for everyone.  
 * [cState](https://github.com/cstate/cstate) - Simple, dev friendly, and free to host (Netlify & GitHub Pages)
-* [StashBoard](http://www.stashboard.org/) - Python, for Google App Engine
+* [StashBoard](http://www.stashboard.org/) - Python, for Google App Engine (*Deprecated*)
 * [Staytus](https://staytus.co/)
 * [Statusfy](https://statusfy.co)
-* [LambStatus](https://lambstatus.github.io)
+* [LambStatus](https://lambstatus.github.io) (*Deprecated*)
 * [StatusOK](https://github.com/sanathp/statusok)
 * [Statping](https://github.com/hunterlong/statping)
 * [Server-Status](https://github.com/Pryx/server-status)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Awesome list of status pages open source software, online services and public st
 * [Statping](https://github.com/hunterlong/statping)
 * [Server-Status](https://github.com/Pryx/server-status)
 * [Kardio](https://github.com/tmobile/kardio) - Simple Health Status Tool with Rich UI for Services deployed on Kubernetes and other platforms.
-* [Staytus](https://github.com/batiron/status)
+* [Staytus](https://github.com/batiron/status) (*Deprecated*)
 
 
 ## Services


### PR DESCRIPTION
Both StasBooard and LambStatus are in maintenance mode and deprecated.