### PR TITLE
Updated Statuspal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Awesome list of status pages open source software, online services and public st
 * [Statping](https://github.com/hunterlong/statping)
 * [Statusfy](https://marquez.co/statusfy)
 * [StatusOK](https://github.com/sanathp/statusok)
-* [Statuspal](https://github.com/statuspal/statuspal) - A self-hosted CE of [statuspal.io](https://statuspal.io). Last OSS commit was mid-2018, and I unfortunately couldn't get it to work. (Unless you figure out how to make this work, I'd recommend another option)
 * [statuspage](https://github.com/darkpixel/statuspage) - Simple self-hosted open source status page site written in Django (inspired by [Cachet](https://cachethq.io/))
 * [Staytus](https://staytus.co/)  (*Deprecated*)
 * [health_check](https://github.com/ianheggie/health_check) - Simple health check of Rails app for use with uptime checking sites like newrelic and pingdom
@@ -37,6 +36,7 @@ Awesome list of status pages open source software, online services and public st
 * [Tinystatus](https://github.com/bderenzo/tinystatus) - A tiny static status page generator (written in pure shell)
 
 ## Services
+* [Statuspal](https://statuspal.io) - Hosted status pages & monitoring.
 * [Instatus](https://instatus.com) - Free online service with a static & customizable page.
 * [AdminLabs Statuspage](https://www.adminlabs.com/status-page/)
 * ~~[Asserted.io](https://asserted.io) - uptime tests written in Mocha *(Discontinued)*~~
@@ -52,7 +52,6 @@ Awesome list of status pages open source software, online services and public st
 * [StatusKeeper](https://statuskeeper.com/)
 * [StatusKit](https://statuskit.com/)
 * [Statuspage.io](https://www.statuspage.io) - online service from Atlassian
-* [Statuspal.io](https://statuspal.io)
 * ~~[Statusy](https://statusy.co) *(Discontinued)*~~
 * [UpDown.io](https://updown.io/) - uptime monitoring with flexible status with rest api
 * [Uptime Robot](https://uptimerobot.com/)


### PR DESCRIPTION
Statuspal CE is unmaintained and deprecated so removing it.