### PR TITLE
Corrected oneuptime.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Awesome list of status pages open source software, online services and public st
 * [Checkly](https://www.checklyhq.com) - API & E2E monitoring platform
 * [Cronitor.io](https://cronitor.io/status-pages) - Status Pages with built-in monitoring for websites, APIs, cron jobs and heartbeats.
 * [FreshStatus](https://www.freshworks.com/statuspage/)
-* [OneUptime](https://oneuptime.com/product/public-status-page) - OneUptime public and private status pages
+* [OneUptime](https://oneuptime.com/product/status-page) - OneUptime public and private status pages
 * [HetrixTools](https://hetrixtools.com) - uptime monitoring for ips and websites with an integrated status page
 * [Hexadecimal](https://tryhexadecimal.com) - uptime & certificate monitoring and hosted status pages
 * [Hund](https://hund.io/)


### PR DESCRIPTION
The current oneuptime link gives a 404. This is the new link for the status page: https://oneuptime.com/product/status-page