### PR TITLE
Fixed letter casing in "Sony PlayStation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Awesome list of status pages open source software, online services and public st
 * [Steam Status (Unofficial)](https://steamstat.us/) - Steam status page. Popular, but unofficial; Valve doesn't have an official page.
 * [Stripe Status](https://status.stripe.com/) - Stripe system status page
 * [Sumsub](https://status.sumsub.com/) - SumSub status page
-* [Sony Playstation](https://status.playstation.com/) - Sony Playstation status page
+* [Sony PlayStation](https://status.playstation.com/) - Sony PlayStation status page
 * [Tailscale](https://status.tailscale.com/) - Tailscale status page
 * [Trakt](https://status.trakt.tv) - Trakt status page
 * [Twitter API Status](https://api.twitterstat.us/) - Twitter API status page


### PR DESCRIPTION
This is how it's meant to be used.