### PR TITLE
Add PagerDuty's newest release of status pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Awesome list of status pages open source software, online services and public st
 * [NixStats](https://nixstats.com/) - service for servers, web, log and blacklists monitoring
 * [OnlineOrNot](https://onlineornot.com) - hosted public/private status pages with integrated uptime monitoring for websites and APIs
 * [PageFate.com](https://pagefate.com) - free online service with customisable design
+* [PagerDuty Status Pages](https://www.pagerduty.com/platform/business-ops/status-pages/)
 * [PingPong](https://pingpong.one) - incident management, uptime & certificate monitoring and hosted status pages
 * [Rootly](https://rootly.io) - incident response platform with status pages built-in
 * [Pulsetic](https://pulsetic.com/) - create status pages & incident management reports and keep your visitors updated


### PR DESCRIPTION
Thought of committing a change to include PagerDuty's newest release: status pages. These pages offer a multitude of features and must be requested via their sales team, but they are quite nice and fully integrated into PagerDuty.