### PR TITLE
Add whatbroke.today - AI-powered status page aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Status.io](https://status.io)
 * [StatusCast](https://statuscast.com/)
 * [StatusGator](https://statusgator.com/) - Status page aggregator with public and private status pages and website monitoring
-* [whatbroke.today](https://whatbroke.today) - Aggregates status pages from 100+ cloud services. Telegram alerts, RSS feed, JSON API.
+* [whatbroke.today](https://whatbroke.today) - Aggregates status pages from cloud services. Telegram alerts, RSS feed, JSON API.
 * [StatusHub](https://statushub.com/) - Communicate downtime with APIs, web-hooks, and automation
 * [StatusKeeper](https://statuskeeper.com/)
 * [StatusKit](https://statuskit.com/)


### PR DESCRIPTION
Adding [whatbroke.today](https://whatbroke.today) to the Services section alongside other status page aggregators.

**Features:**
- AI-powered aggregator monitoring 100+ cloud services
- Real-time Telegram alerts (@whatbroketoday)
- AI-generated incident summaries
- RSS feed for DevOps workflows
- Free to use

Similar to StatusGator and IsDown.app but with AI-powered summaries.