### PR TITLE
Add VisualSentinel to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Uptime Robot](https://uptimerobot.com/)
 * [UptimeToolbox](https://www.uptimetoolbox.com/) - Website/Server monitors with status pages.
 * [Uptimia](https://www.uptimia.com/) - Website monitoring, on-call alerting with status pages.
+* [VisualSentinel](https://visualsentinel.com) - Public status pages with built-in monitoring across uptime, visual change detection, SSL, DNS, performance and content. Free tier available.
 * [WebGazer](https://www.webgazer.io) - Uptime monitoring, cron job monitoring and hosted status pages.
 * [Xitoring](https://xitoring.com) - Uptime monitoring, Server monitoring, built-in hosted status pages.
 


### PR DESCRIPTION
Adding VisualSentinel under Services, alphabetically between Uptimia and WebGazer. Runs hosted status pages on top of its own monitoring (uptime, visual diff, SSL, DNS, performance, content). Free tier is available. Not currently in the list.

I run the service and wrote this entry myself.