### PR TITLE
Add Uptrack to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Uptime Robot](https://uptimerobot.com/)
 * [UptimeToolbox](https://www.uptimetoolbox.com/) - Website/Server monitors with status pages.
 * [Uptimia](https://www.uptimia.com/) - Website monitoring, on-call alerting with status pages.
+* [Uptrack](https://uptrack.app) - Uptime monitoring with 30s free checks, consecutive-check alert confirmation, hosted status pages, and a built-in MCP server for AI agents.
 * [WebGazer](https://www.webgazer.io) - Uptime monitoring, cron job monitoring and hosted status pages.
 * [Xitoring](https://xitoring.com) - Uptime monitoring, Server monitoring, built-in hosted status pages.
 


### PR DESCRIPTION
Adds [Uptrack](https://uptrack.app) to the Services section in alphabetical order (between Uptimia and WebGazer).

Uptrack is a SaaS uptime monitoring tool with hosted status pages. Differentiators vs other entries:
- 30-second checks on the free tier
- Consecutive-check alert confirmation (reduces false positives)
- Built-in MCP server ([@uptrack-app/mcp](https://github.com/Uptrack-App/uptrack-mcp)) for AI agents (Claude, ChatGPT, Cursor, VS Code)

Hosted status pages are included on every plan, with custom domains + theming on paid tiers.