### PR TITLE
Add KubeStellar Console to Hosting and Cloud section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [UptimeFlare](https://github.com/lyc8503/UptimeFlare) - Another monitoring & status page completely powered by Cloudflare Workers & Pages.
 * [Kener](https://kener.ing/) - A SvelteKit + Node.js status page with incident management.
 * [YASP](https://yasp.io) - Yet Another Status Page based on Next.JS and Payload CMS. SMTP and Twilio integrations. One-click hostable on Vercel.
+- [KubeStellar Console](https://github.com/kubestellar/console) — Multi-cluster Kubernetes management console with built-in cluster health dashboards; provides real-time status monitoring across cloud and edge Kubernetes deployments.
 
 ## Services
 * [AdminLabs Statuspage](https://www.adminlabs.com/status-page/)


### PR DESCRIPTION
KubeStellar Console includes cluster health status dashboards for Kubernetes — monitoring workload health, node status, and service availability across multiple cloud environments.

https://github.com/kubestellar/console | https://console.kubestellar.io