### PR TITLE
Add AIWatch to Opensource section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Hosting and Cloud](#hosting-and-cloud)
 
 ## Opensource
+* [AIWatch](https://github.com/bentleypark/aiwatch) - Open-source dashboard for monitoring third-party AI services (31 services including Claude, OpenAI, Gemini, Mistral, Groq) with reliability scoring, incident analysis, and Discord/Slack alerts. Built on Cloudflare Workers + KV. Live demo at https://ai-watch.dev. AGPL-3.0.
 * [aPulse](https://github.com/ybouane/aPulse) - A One-File Nodejs Server Status Monitoring Tool.
 * [Cachet](https://cachethq.io/) - Laravel based status page system for everyone. [3.x coming soon](https://github.com/cachethq/cachet/discussions/4342).
 * [Checkmate](https://github.com/bluewave-labs/Checkmate) (previously "BlueWave Uptime") - Checkmate is an open-source, self-hosted monitoring tool built with React.js, Node.js, and MongoDB, designed to track server uptime, response times, and incidents in real-time, featuring a modern UI. Additionally, Checkmate supports E-mail, Webhook, Discord and Slack notifications and has a multi-language frontend.


### PR DESCRIPTION
Adds AIWatch to the Opensource section in alphabetical order (above aPulse).

AIWatch is an open-source dashboard for monitoring the reliability of 31 third-party AI services (Claude, OpenAI, Gemini, Mistral, Cohere, Groq, ElevenLabs, and others). Built on Cloudflare Workers + KV.

Differentiators vs other entries:
- AI-services-specific (most existing entries are generic uptime monitoring)
- Composite reliability score combining uptime, incidents, recovery, and probe latency
- Direct API probing surfaces outages ahead of the official status pages

Live demo: https://ai-watch.dev
Source: https://github.com/bentleypark/aiwatch (AGPL-3.0)