### PR TITLE
Add Drumbeats.io to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Checkly](https://www.checklyhq.com) - API & E2E monitoring platform
 * [Chirp](https://getchirp.dev) - Monitoring and status pages for indie hackers and small teams, with uptime checks, incident management, and email notifications
 * [Cronitor.io](https://cronitor.io/status-pages) - Status Pages with built-in monitoring for websites, APIs, cron jobs and heartbeats.
+* [Drumbeats.io](https://drumbeats.io/) - One-click status pages and incident management for cron, heartbeat, HTTP, and uptime monitors. 
 * [FlareWarden](https://flarewarden.com/status-pages) - Status pages with incident management, maintenance windows, and built-in multi-region uptime monitoring. Free tier available.
 * [FreshStatus](https://www.freshworks.com/statuspage/)
 * [Garmingo Status](https://garmingo.com/status) - Uptime monitoring and status pages for websites, APIs, ...

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Checkly](https://www.checklyhq.com) - API & E2E monitoring platform
 * [Chirp](https://getchirp.dev) - Monitoring and status pages for indie hackers and small teams, with uptime checks, incident management, and email notifications
 * [Cronitor.io](https://cronitor.io/status-pages) - Status Pages with built-in monitoring for websites, APIs, cron jobs and heartbeats.
-* [Drumbeats.io](https://drumbeats.io/) - One-click status pages and incident management for cron, heartbeat, HTTP, and uptime monitors. 
+* [Drumbeats.io](https://drumbeats.io/) - Status pages and incident management for cron, heartbeat, HTTP, and uptime monitors. 
 * [FlareWarden](https://flarewarden.com/status-pages) - Status pages with incident management, maintenance windows, and built-in multi-region uptime monitoring. Free tier available.
 * [FreshStatus](https://www.freshworks.com/statuspage/)
 * [Garmingo Status](https://garmingo.com/status) - Uptime monitoring and status pages for websites, APIs, ...


### PR DESCRIPTION
Adds [Drumbeats](https://drumbeats.io/) to the Services list, including a brief description of its capabilities. It has a very large free tier with up to 50 monitors and status pages and unlimited seats.