### PR TITLE
Add Uptimeify.io to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [UpReport](https://up.report/free-status-page) - Free status page, uptime monitoring, and alerting for early-stage products
 * [Uptime.com](https://uptime.com) - Website Monitoring, Status Pages (Private & Public) and Incident Management.
 * [Uptime Robot](https://uptimerobot.com/)
+* [Uptimeify.io](https://uptimeify.io) - Website and API monitoring with hosted status pages to visualize service uptime and performance.
 * [UptimeToolbox](https://www.uptimetoolbox.com/) - Website/Server monitors with status pages.
 * [Uptimia](https://www.uptimia.com/) - Website monitoring, on-call alerting with status pages.
 * [Uptrack](https://uptrack.app) - Uptime monitoring with 30s free checks, consecutive-check alert confirmation, hosted status pages, and a built-in MCP server for AI agents.


### PR DESCRIPTION
Hey, I'm the developer of Uptimeify. I'd like to add it to the services section as it provides hosted status pages for website and API monitoring. 

Thanks for checking! 