### PR TITLE
Add SitePulse to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Rootly](https://rootly.io) - incident response platform with status pages built-in
 * [Pulsetic](https://pulsetic.com/) - create status pages & incident management reports and keep your visitors updated
 * [Sematext Cloud](https://sematext.com/status-pages-and-incidents/) - public & private status pages with incidents, uptime metrics and charts offered as part of Sematext Synthetics
+* [SitePulse](https://sitepulse.satosushi.co) - Flat-priced uptime monitoring and free public status pages for indie developers, with 1-minute checks and email alerts.
 * [Middleware](https://middleware.io/product/synthetic-monitoring/) - track performance of API and webpages with real-time alerts and uptime monitoring
 * [Sorry™](https://www.sorryapp.com)
 * [Spork Status Pages](https://sporkops.com) - Status pages with custom domains, auto-incidents from uptime monitoring, and webhook/RSS notifications.


### PR DESCRIPTION
Adding SitePulse to the Services section.

## What is it
SitePulse is a flat-priced uptime monitor with a free public status page on every plan, built for indie developers and small teams.

## Why it fits this list
SitePulse includes hosted public status pages as a core feature on all plans (including the free tier), with custom slugs at sitepulse.satosushi.co/status/<slug>. Status pages auto-update from real monitor data every minute.

## Details
- Pricing: Free for 5 monitors / $9/mo for 25 / $29/mo for 150
- Check interval: 5-min on Free, 1-min on Pro
- Alerts: email today (Slack/SMS on the roadmap)
- Live demo status page: https://sitepulse.satosushi.co/status/sitepulse
- Public marketing site: https://sitepulse.satosushi.co

The product launched in late April 2026. Built solo from Tokyo.