### PR TITLE
Add DevHelm to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Checkly](https://www.checklyhq.com) - API & E2E monitoring platform
 * [Chirp](https://getchirp.dev) - Monitoring and status pages for indie hackers and small teams, with uptime checks, incident management, and email notifications
 * [Cronitor.io](https://cronitor.io/status-pages) - Status Pages with built-in monitoring for websites, APIs, cron jobs and heartbeats.
+* [DevHelm](https://devhelm.io) - Developer-first uptime monitoring with hosted status pages, dependency intelligence for 80+ third-party providers, and a full developer surface (CLI, SDKs, Terraform, MCP server). Free tier: 50 monitors.
 * [Drumbeats.io](https://drumbeats.io/) - Status pages and incident management for cron, heartbeat, HTTP, and uptime monitors. 
 * [FlareWarden](https://flarewarden.com/status-pages) - Status pages with incident management, maintenance windows, and built-in multi-region uptime monitoring. Free tier available.
 * [FreshStatus](https://www.freshworks.com/statuspage/)


### PR DESCRIPTION
## What is DevHelm?

[DevHelm](https://devhelm.io) is a developer-first uptime monitoring platform that provides:

- **Uptime monitoring** — HTTP, DNS, TCP, ICMP, and heartbeat checks
- **Dependency intelligence** — track the status of 80+ third-party providers your services depend on
- **Hosted status pages** — with custom domain support
- **Full developer surface** — CLI, Python SDK, JS/TS SDK, Terraform provider, and MCP server for AI agents
- **Config-as-code** — define monitors in `devhelm.yml`

**Free tier:** 50 monitors + status page

- Website: https://devhelm.io
- Docs: https://docs.devhelm.io
- GitHub: https://github.com/devhelmhq

## Why it fits the Services section

DevHelm offers hosted status pages as a core feature, fitting alongside other monitoring services with built-in status pages like Better Stack, Checkly, and Cronitor.

## Changes

Added DevHelm entry to the Services section in alphabetical order, following the existing `* [Name](url) - Description` format.