### PR TITLE
Add DownForAI to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Uptrack](https://uptrack.app) - Uptime monitoring with 30s free checks, consecutive-check alert confirmation, hosted status pages, and a built-in MCP server for AI agents.
 * [WebGazer](https://www.webgazer.io) - Uptime monitoring, cron job monitoring and hosted status pages.
 * [Xitoring](https://xitoring.com) - Uptime monitoring, Server monitoring, built-in hosted status pages.
+* [DownForAI](https://downforai.com) - Status page aggregator for AI services with real-time monitoring of 800+ AI tools and APIs (OpenAI, Anthropic, Gemini, Groq, Midjourney, etc.). Free public API and SVG status badges.
 
 ## Public Status Pages
 * [Absurd Design](https://status.absurd.design/) - Absurd Design status


### PR DESCRIPTION
Adds DownForAI to the Services section.

DownForAI is a status page aggregator focused specifically on AI services. It monitors 800+ AI tools and APIs in real-time (OpenAI, Anthropic, Google Gemini, Groq, Midjourney, GitHub Copilot, etc.) with uptime checks, latency tracking, community outage reports, free public API, and SVG status badges.

Similar tools already in the Services section: API Status Check, IsDown.app, IncidentHub, StatusGator, StatusSight, whatbroke.today.

This PR was written and submitted manually by me (the maintainer of DownForAI). Not generated by an AI tool.