### PR TITLE
Add Prismix to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Pagerly](https://pagerly.io) - Oncalls and Incidence response with custom domain hosted status pages and uptime monitoring
 * [PingPong](https://pingpong.one) - incident management, uptime & certificate monitoring and hosted status pages
 * [Phare](https://phare.io/products/uptime/status-pages) - Uptime monitoring, alerts, incidents, analytics, and status pages
-* [Prismix](https://prismix.dev/status) - Status aggregator for AI services (OpenAI, Anthropic, Cursor, Mistral, etc.) with starred-service alerts, embeddable badges, 30-day uptime, and a 3-pillar dashboard adding curated AI news + MCP server directory alongside status.
+* [Prismix](https://prismix.dev/status) - Status page aggregator for AI services (OpenAI, Anthropic, Cursor, Mistral, etc.) with starred-service email/webhook alerts, embeddable SVG badges, 30-day uptime history, and an incident timeline. Free public API.
 * [Rootly](https://rootly.io) - incident response platform with status pages built-in
 * [Pulsetic](https://pulsetic.com/) - create status pages & incident management reports and keep your visitors updated
 * [Sematext Cloud](https://sematext.com/status-pages-and-incidents/) - public & private status pages with incidents, uptime metrics and charts offered as part of Sematext Synthetics

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Pagerly](https://pagerly.io) - Oncalls and Incidence response with custom domain hosted status pages and uptime monitoring
 * [PingPong](https://pingpong.one) - incident management, uptime & certificate monitoring and hosted status pages
 * [Phare](https://phare.io/products/uptime/status-pages) - Uptime monitoring, alerts, incidents, analytics, and status pages
+* [Prismix](https://prismix.dev/status) - Status aggregator for AI services (OpenAI, Anthropic, Cursor, Mistral, etc.) with starred-service alerts, embeddable badges, 30-day uptime, and a 3-pillar dashboard adding curated AI news + MCP server directory alongside status.
 * [Rootly](https://rootly.io) - incident response platform with status pages built-in
 * [Pulsetic](https://pulsetic.com/) - create status pages & incident management reports and keep your visitors updated
 * [Sematext Cloud](https://sematext.com/status-pages-and-incidents/) - public & private status pages with incidents, uptime metrics and charts offered as part of Sematext Synthetics


### PR DESCRIPTION
Adds [Prismix](https://prismix.dev/status) to the **Services** section.

Prismix is a status aggregator specifically for the AI tooling space (OpenAI, Anthropic, Cursor, Mistral, Hugging Face, GitHub Copilot, Cohere, etc.) with a deliberately curated 75+ service set — distinct positioning from broader aggregators like DownForAI (800+ tools) and StatusGator (general cloud).

What's in the entry:
- Star-your-favorites with email + Discord/Slack/generic webhook alerts on state transitions
- 30-day uptime history per service + 24h latency sparkline
- Embeddable SVG status badges (Shields-style) for any service
- Free public REST API at `/api/v1/statuses` + Atom feed for cross-service incidents at `/incidents.rss`
- 3-pillar dashboard — status + curated AI news (70+ sources) + 500+ MCP server directory in one place

Built on Cloudflare Workers + KV (free tier, $0/mo to run). Live: https://prismix.dev/status

Inserted in P-alphabetical position between Phare and PingPong. Happy to move if you prefer DownForAI-adjacent or end-of-list.