### PR TITLE
Add Prismix — AI status monitoring hub for 75+ AI services

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Uptrack](https://uptrack.app) - Uptime monitoring with 30s free checks, consecutive-check alert confirmation, hosted status pages, and a built-in MCP server for AI agents.
 * [WebGazer](https://www.webgazer.io) - Uptime monitoring, cron job monitoring and hosted status pages.
 * [Xitoring](https://xitoring.com) - Uptime monitoring, Server monitoring, built-in hosted status pages.
+* [Prismix](https://prismix.dev) - AI hub with real-time status monitoring for 75+ AI services (OpenAI, Anthropic, Groq, Mistral, etc.), news aggregation from 70+ sources, and an MCP server directory. Features incidents timeline, email/webhook alerts, public REST API, embeddable SVG badges, and a badge embed API. Built on Cloudflare Workers + KV.
 * [DownForAI](https://downforai.com) - Status page aggregator for AI services with real-time monitoring of 800+ AI tools and APIs (OpenAI, Anthropic, Gemini, Groq, Midjourney, etc.). Free public API and SVG status badges.
 
 ## Public Status Pages


### PR DESCRIPTION
Adds Prismix to the Services section.

Prismix is an AI status aggregator and hub:
- Real-time monitoring for **75+ AI services** (OpenAI, Anthropic, Groq, Mistral, Cursor, Midjourney, etc.)
- Cross-service **incidents timeline** with permalinked incident pages
- Email and webhook alerts (Discord/Slack auto-detected)
- **Public REST API** at `https://prismix.dev/api/v1/statuses`
- **Embeddable SVG badges** (`/api/badge/{service}.svg`) with live status colors
- MCP server directory and AI news aggregation as companion pillars

Live: https://prismix.dev
API docs: https://prismix.dev/api-docs