### PR TITLE
Add SonarOps to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Awesome list of status pages opensource software, online services, and public st
 * [Pulsetic](https://pulsetic.com/) - create status pages & incident management reports and keep your visitors updated
 * [Sematext Cloud](https://sematext.com/status-pages-and-incidents/) - public & private status pages with incidents, uptime metrics and charts offered as part of Sematext Synthetics
 * [Middleware](https://middleware.io/product/synthetic-monitoring/) - track performance of API and webpages with real-time alerts and uptime monitoring
+* [SonarOps](https://www.sonarops.it/features/status-pages) - Public, custom-domain status pages backed by cross-region uptime monitoring — a second probe in another region confirms an outage before it shows, plus SSL and page-weight checks.
 * [Sorry™](https://www.sorryapp.com)
 * [Spork Status Pages](https://sporkops.com) - Status pages with custom domains, auto-incidents from uptime monitoring, and webhook/RSS notifications.
 * [Squadcast](https://www.squadcast.com) - On-Call & SRE platform with StatusPages built-in


### PR DESCRIPTION
Adds SonarOps to the Services list — public, custom-domain status pages backed by cross-region uptime monitoring (a second probe in another region confirms an outage before it's shown), with SSL and page-weight checks. Independent, solo-developer product. Placed alphabetically in the Services section.